### PR TITLE
Fix invalid Curseforge URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@ The goal of this mod is to add several new banners to Minecraft. This mod also s
 [![Nodecraft](https://nodecraft.com/assets/images/logo-dark.png)](https://nodecraft.com/r/darkhax)
 This project is sponsored by Nodecraft. Use code [Darkhax](https://nodecraft.com/r/darkhax) for 30% off your first month of service!
 
-You can download the mod [here](http://minecraft.curseforge.com/projects/additional-banners-expand-your-options).
+You can download the mod [here](https://www.curseforge.com/minecraft/mc-mods/additional-banners).


### PR DESCRIPTION
The URL on the readme is leading to a non-existing site, which is fixed by this PR.